### PR TITLE
Allow `hexRadius` configuration as miles/kilometres - Issue#4

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ Please [see this notebook](https://beta.observablehq.com/@larsvers/hexgrid-maps-
 
 Go straight to the [API reference](#api-reference).
 
-
 ## Install
 
 ```
@@ -27,7 +26,6 @@ Or you can use [unpkg](https://unpkg.com/) to script-link to _d3-hexgrid_:
 <script src="https://unpkg.com/d3-hexgrid"></script>
 ```
 
-
 ## Examples
 
 #### Militarised interstate disputes in Europe 1816-2001
@@ -35,7 +33,6 @@ Or you can use [unpkg](https://unpkg.com/) to script-link to _d3-hexgrid_:
 ![disputes](https://raw.githubusercontent.com/larsvers/image-store/master/d3-hexgrid/disputes.jpg)
 
 <sub>Data source: [Midloc via data.world](https://data.world/cow/militarized-dispute-locations/). Additional clip-path applied. • [code](https://bl.ocks.org/larsvers/049c8f382ea07d48ca0a395e661d0fa4)</sub>
-
 
 #### Cities across the world
 
@@ -49,31 +46,29 @@ Or you can use [unpkg](https://unpkg.com/) to script-link to _d3-hexgrid_:
 
 <sub>Data source: [USDA](https://www.ams.usda.gov/local-food-directories/farmersmarkets) • [code](https://bl.ocks.org/larsvers/7f856d848e1f5c007553a9cea8a73538)</sub>
 
-#### Post boxes in the UK 
+#### Post boxes in the UK
 
 ![postboxes](https://raw.githubusercontent.com/larsvers/image-store/master/d3-hexgrid/postboxes.jpg)
 
 <sub>Data source: [dracos.co.uk](http://dracos.co.uk/) from [here](http://dracos.co.uk/made/locating-postboxes) via [Free GIS Data](https://freegisdata.rtwilson.com/) • [code](https://bl.ocks.org/larsvers/a05405dd9476e5842a1dbbc93b3d1cf7)</sub>
 
-
 ### Edge Cover
 
-The tessellation aspect might become clear in these examples. The edge cover calculation might not. In short, _d3.hexgrid_ identifies all **edge hexagons** that partly lie beyond the borders of the geography, or more general: the base image presented. In a next step it calculates the edge hexagon's **cover**: the area the edge hexagon lies within the bounds of the base image in percent. Lastly, the **point density** will be calculated by: 
+The tessellation aspect might become clear in these examples. The edge cover calculation might not. In short, _d3.hexgrid_ identifies all **edge hexagons** that partly lie beyond the borders of the geography, or more general: the base image presented. In a next step it calculates the edge hexagon's **cover**: the area the edge hexagon lies within the bounds of the base image in percent. Lastly, the **point density** will be calculated by:
 
-_Point density = Points in hexagon / Hexagon area in px<sup>2</sup> * Cover_
+_Point density = Points in hexagon / Hexagon area in px<sup>2</sup> &times; Cover_
 
 A comparison:
 
 ![edge comparison](https://raw.githubusercontent.com/larsvers/image-store/master/d3-hexgrid/edge-compare.jpg)
 
-Both maps encode the number of Farmer's Markets per hexagon. Yellow represents a low, purple a high number. The edge hexagons of the upper map are not cover corrected, the edge hexagons of the lower map are. 
+Both maps encode the number of Farmer's Markets per hexagon. Yellow represents a low, purple a high number. The edge hexagons of the upper map are not cover corrected, the edge hexagons of the lower map are.
 
 The edge hexagon at the south-eastern tip of Florida we're comparing has a cover of 55%, meaning 55% of the hexagon's area is inland, 45% is in the Atlantic. There are a total of 22 Farmer's Markets in this hexagon. Not cover corrected, the hexagon would have a point density of 0.09 and would be filled in a dark blue with the colour scale of choice. When cover corrected, its real point density increases to 0.17 and it is coloured in a dark purple&mdash;indicating higher point density as it should.
 
 Differences might be subtle but noticeable.
 
-Please see the d3-hexgrid's notebook [section on edge cover](https://beta.observablehq.com/@larsvers/hexgrid-maps-with-d3-hexgrid#coverChapter) for a detailed description of the cover calculation. 
-
+Please see the d3-hexgrid's notebook [section on edge cover](https://beta.observablehq.com/@larsvers/hexgrid-maps-with-d3-hexgrid#coverChapter) for a detailed description of the cover calculation.
 
 ## Example usage
 
@@ -97,12 +92,12 @@ const hexgrid = d3.hexgrid()
   .projection(projection)
   .pathGenerator(geoPath);
 
-// Get the hexbin generator and the layout. 
+// Get the hexbin generator and the layout.
 const hex = hexgrid(myPointLocationData);
 
 // Create a colour scale.
 const colourScale = d3.scaleSequential(d3.interpolateViridis)
-  .domain([...hex.grid.maxPoints].reverse()); 
+  .domain([...hex.grid.maxPoints].reverse());
 
 // Draw the hexes.
 svg.append('g')
@@ -129,6 +124,7 @@ const svg = d3.select('body')
 const projection = d3.geoAlbers().fitSize([width, height], geo);
 const geoPath = d3.geoPath().projection(projection);
 ```
+
 Next, we use `d3.hexgrid()` to produce a _hexgrid_ instance we creatively call `hexgrid`. We immediately configure it by passing in the extent, the GeoJSON, the projection and the path-generator.
 
 ```
@@ -138,22 +134,23 @@ const hexgrid = d3.hexgrid()
   .projection(projection)
   .pathGenerator(geoPath);
 ```
-Now we can call our _hexgrid_ instance passing in the data. 
+
+Now we can call our _hexgrid_ instance passing in the data.
 
 ```
 const hex = hexgrid(myPointLocationData);
 ```
 
- This will return a hexbin generator as [`d3.hexbin()`](https://github.com/d3/d3-hexbin) does, augmented with an additional object called <a href="#grid-object" name="grid-object">`grid`</a>, which exposes the following properties:
+This will return a hexbin generator as [`d3.hexbin()`](https://github.com/d3/d3-hexbin) does, augmented with an additional object called <a href="#grid-object" name="grid-object">`grid`</a>, which exposes the following properties:
 
 ![grid object](https://raw.githubusercontent.com/larsvers/image-store/master/d3-hexgrid/grid-object.jpg)
 
-* `imageCenters` is an array of objects exposing at least the _x_, _y_ hexagon centre coordinates of the hexgrid in screen space.
+- `imageCenters` is an array of objects exposing at least the _x_, _y_ hexagon centre coordinates of the hexgrid in screen space.
 
-* `layout` is an array of arrays, each sub-array representing a hexagon in the grid. Each sub-array holds all point locations per hexagon in an object exposing at least _x_ and _y_ pixel coordinates as well as aggregate values. Here's an example hexagon layout sub-array with three point locations (or _datapoints_):
+- `layout` is an array of arrays, each sub-array representing a hexagon in the grid. Each sub-array holds all point locations per hexagon in an object exposing at least _x_ and _y_ pixel coordinates as well as aggregate values. Here's an example hexagon layout sub-array with three point locations (or _datapoints_):
 
   ![layout object](https://raw.githubusercontent.com/larsvers/image-store/master/d3-hexgrid/layout-object.jpg)
-  
+
   The aggregate values per hexagon are:
 
   - `cover` is the percentage of this hexagon's area within the geography expressed as a number between 0 and 1.
@@ -163,19 +160,19 @@ const hex = hexgrid(myPointLocationData);
   - `gridpoint` marks the hexagon as part of the initial hexgrid. This allows you to identify hexagons added by the data. Imprecise latitude and longitude data values can lead to the generation of hexagons just outside the hexgrid. _d3.hexgrid_ will still capture and produce them. But you can spot and treat them by filtering for `gridpoint === 0`.
   - `x` and `y` are the hexagon centre positions in pixel coordinates.
 
-* `extentPoints` is the extent of point location counts over all hexagons in the form _[min number of points, max number of points]_.
-* `extentPointsWeighted` is the extent of point location counts weighted by their cover over all hexagons in the form _[min number of weighted points, max number of weighted points]_.
-* `extentPointDensity` is the extent of cover adjusted point density over all hexagons in the form _[min point density, max point density]_.
+- `extentPoints` is the extent of point location counts over all hexagons in the form _[min number of points, max number of points]_.
+- `extentPointsWeighted` is the extent of point location counts weighted by their cover over all hexagons in the form _[min number of weighted points, max number of weighted points]_.
+- `extentPointDensity` is the extent of cover adjusted point density over all hexagons in the form _[min point density, max point density]_.
 
   These extents can be used to set a colour scale domain when encoding number of points or point density.
 
-  
 Working with points, for example, we might want to create the following colour scale:
 
 ```
 const colourScale = d3.scaleSequential(d3.interpolateViridis)
-  .domain([...hex.grid.maxPoints].reverse()); 
+  .domain([...hex.grid.maxPoints].reverse());
 ```
+
 Here, we decide to encode the number of points per hexagon as colours along the spectrum of the [Viridis colour map](https://github.com/d3/d3-scale-chromatic#interpolateViridis) and create an appropriate colour scale. We reverse the extent (without modifying the original array) as we want to map the maximum value to the darkest colour, which the Viridis colour space starts with.
 
 Finally, we build the visual:
@@ -191,17 +188,14 @@ svg.append('g')
   .attr('transform', d => `translate(${d.x}, ${d.y})`)
   .style('fill', d => !d.datapoints ? '#fff' : colourScale(d.datapoints));
 ```
+
 We use the `hex.grid.layout` to produce as many path's as there are hexagons&mdash;as we would with `d3.hexbin()`&mdash;now, however, making sure we have as many hexagons to cover our entire GeoJSON polygon. We draw each hexagon with with `hexgrid.hexagon()` and `translate` them into place. Lastly, we give our empty hexagons (`!d.datapoints`) a white fill and colour encode all other hexagons depending on their number of `datapoints`.
-
-
 
 ## API Reference
 
-
 <a href="#hexgrid" name="hexgrid">#</a> d3.<b>hexgrid</b>()
 
-Constructs a hexgrid generator called _hexgrid_ in the following. To be configured before calling it with the data you plan to visualise. 
-
+Constructs a hexgrid generator called _hexgrid_ in the following. To be configured before calling it with the data you plan to visualise.
 
 <a href="#hex" name="hex">#</a> _hexgrid_(_data_[, _names_])
 
@@ -226,32 +220,32 @@ hexgrid.extent([[0, 0], [width, height]]);
 hexgrid.extent([width, height]);
 ```
 
-
 <a href="#hex-geography" name="hex-geography">#</a> _hexgrid._<b>geography</b>([_object_])
 
-_Required_. _object_ represents the base polygon for the hexgrid in GeoJSON format. If you were to project a hexgrid onto Bhutan, _object_ would be a GeoJSON object of Bhutan. 
-
+_Required_. _object_ represents the base polygon for the hexgrid in GeoJSON format. If you were to project a hexgrid onto Bhutan, _object_ would be a GeoJSON object of Bhutan.
 
 <a href="#hex-projection" name="hex-projection">#</a> _hexgrid._<b>projection</b>([_projection_])
 
 _Required_. _projection_ is the projection function for the previously defined [_geography_](#hex-geography) commonly specified within the bounds of [_extent_](#hex-extent). See [here](https://github.com/d3/d3-geo) or [here](https://github.com/d3/d3-geo-projection) for a large pond of projection functions.
 
-
 <a href="#hex-pathGenerator" name="hex-pathGenerator">#</a> _hexgrid._<b>pathGenerator</b>([_path_])
 
 _Required_. _path_ is the path generator to produce the drawing instructions of the previously defined [_geography_](#hex-geography) based on the also previously defined [_projection_](#hex-projection).
 
+<a href="#hex-hexRadius" name="hex-hexRadius">#</a> _hexgrid._<b>hexRadius</b>([_radius_[, _unit_]])
 
-<a href="#hex-hexRadius" name="hex-hexRadius">#</a> _hexgrid._<b>hexRadius</b>([_radius_])
+_Optional_. The desired hexagon radius in pixel. Defaults to 4. _unit_ can optionally be specified if the radius should be expressed not in pixel but in either _"miles"_ or _"kilometres"_. The following is valid configuration:
 
-_Optional_. The desired hexagon radius in pixel. Defaults to 4.
+```js
+.hexRadius(50, 'm')   // or 'miles'
+.hexRadius(50, 'km')  // or 'kilometres' or 'kilometers'
+```
 
-
+The conversion is based on a [`geoCircle`](https://github.com/d3/d3-geo#geoCircle) projected in the center of the drawing area. As such the conversion can only be a proxy, however, a good one if an equal area projection is used to minimise area distortions across the geography.
 
 <a href="#hex-edgePrecision" name="hex-edgePrecision">#</a> _hexgrid._<b>edgePrecision</b>([_precision_])
 
 _Optional_. The edge precision sets the size of the internally produced canvas to identify which area of the edge hexagon is covered by the [_geography_](#hex-geography). The higher the precision, the better the pixel detection at the hexagon edges. Values can be larger than 1 for small visuals. Values smaller than 0.3 will be coerced to 0.3. The default value of 1 will be fine for most purposes.
-
 
 <a href="#hex-gridExtend" name="hex-gridExtend">#</a> _hexgrid._<b>gridExtend</b>([_extension_])
 
@@ -261,28 +255,25 @@ _Optional_. _gridExtend_ controls the size of the base geography. _gridExtend_ a
 
 _gridExtend_ is measured in units of _hexRadius_. For example, a _gridExtend_ value of 2 would extend the grid by _2 &times; hexRadius_ pixel.
 
-
 <a href="#hex-geoKeys" name="hex-geoKeys">#</a> _hexgrid._<b>geoKeys</b>([_keys_])
 
-_Optional_. _d3.hexgrid_ will try to guess the key names for longitude and latitude variables in your data. The following case-insensitive key names will be sniffed out: 
+_Optional_. _d3.hexgrid_ will try to guess the key names for longitude and latitude variables in your data. The following case-insensitive key names will be sniffed out:
 
-* _longitude_, _long_, _lon_, _lng_, _lambda_ as well as 
-* _latitude_, _lat_ and _phi_.
+- _longitude_, _long_, _lon_, _lng_, _lambda_ as well as
+- _latitude_, _lat_ and _phi_.
 
-If you choose other names like for example _upDown_ and _leftRight_, you 
-have to specify them as <code><i>hexgrid</i>.geokeys(['upDown', 'leftRight'])</code> with the first element representing longitude and the second latitude. 
+If you choose other names like for example _upDown_ and _leftRight_, you
+have to specify them as <code><i>hexgrid</i>.geokeys(['upDown', 'leftRight'])</code> with the first element representing longitude and the second latitude.
 
 Don't call your geo keys `x` or `y` or otherwise include `x` and/or `y` keys in your passed in user variables as they are reserved keys for the pixel coordinates of the layout.
 
-
-
 ### Helper functions
 
-The following functions can be helpful to filter out point location data that lie beyond the base geography. 
+The following functions can be helpful to filter out point location data that lie beyond the base geography.
 
 <a href="#d3-geoPolygon" name="d3-geoPolygon">#</a> d3.<b>geoPolygon</b>([_geo_, _projection_])
 
-Transforms a GeoJSON geography into a Polygon or MultiPolygon. _geo_ is a GeoJSON of the base geography. _projection_ is the applied projection function. 
+Transforms a GeoJSON geography into a Polygon or MultiPolygon. _geo_ is a GeoJSON of the base geography. _projection_ is the applied projection function.
 
 <a href="#d3-polygonPoints" name="d3-polygonPoints">#</a> d3.<b>polygonPoints</b>([_data_, _polygon_])
 
@@ -307,14 +298,13 @@ While being the right choice in many cases, two notes should be considered when 
 
 The world is [something like a sphere](https://en.wikipedia.org/wiki/Spheroid) and there are numerous ways to project a sphere onto a 2D plane. The projection used has an important effect on the analysis. Any tessellation normalises space to equally sized units&mdash;hexagons in this case&mdash;which invites the reader to assume that each unit covers the same area. However, some projections, like the ubiquitous Mercator projection, will distort area increasingly towards the poles:
 
-
 ![mercator](https://raw.githubusercontent.com/larsvers/image-store/master/d3-hexgrid/mercator.jpg)
 
 <sub>Source: [D3 in depth](http://d3indepth.com/geographic/) by [Peter Cook](http://animateddata.co.uk/)
 
 All red circles on above map are of the same area. As a result, tessellating a Mercator world map with hexagons will produce many more hexagons per square mile in Norway compared to Brazil, for example.
 
-[Equal area projections](https://github.com/d3/d3-geo-projection#geoConicEqualArea) will help to avoid this problem to a large extent. 
+[Equal area projections](https://github.com/d3/d3-geo-projection#geoConicEqualArea) will help to avoid this problem to a large extent.
 
 #### Consciously choose the hexagon radius size.
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "homepage": "https://github.com/larsvers/d3-hexgrid",
   "author": {
     "name": "Lars Verspohl",
-    "url": "http://www.datamake.io"
+    "url": "https://www.datamake.io"
   },
   "license": "BSD-3-Clause",
   "main": "dist/d3-hexgrid.js",
@@ -36,7 +36,6 @@
     "babel-plugin-external-helpers": "^6.22",
     "babel-preset-env": "^1.7",
     "canvas": "^1.6",
-    "d3-geo": "^1.10",
     "eslint": "^4.19.1",
     "eslint-config-airbnb": "^17.0.0",
     "eslint-config-airbnb-base": "^13.0.0",
@@ -56,6 +55,7 @@
   },
   "dependencies": {
     "d3-array": "^1.2",
+    "d3-geo": "^1.10",
     "d3-hexbin": "^0.2",
     "d3-polygon": "^1.0"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d3-hexgrid",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Regular hexagon tessellation with edge cover detection.",
   "keywords": [
     "d3",

--- a/src/convertUnitRadius.js
+++ b/src/convertUnitRadius.js
@@ -1,0 +1,56 @@
+import { geoCircle } from 'd3-geo';
+import { getPixelRadius } from './utils';
+
+/**
+ * Sniffs the unit and converts to either "m" or "km".
+ * @param   {string} unit The user given unit.
+ * @return  {string}      The clean unit string.
+ */
+function getUnitString(unit) {
+  let unitLower = unit.toLowerCase();
+
+  if (unitLower === 'm' || unitLower === 'km') {
+    return unitLower;
+  } else if (
+    unitLower === 'kilometres' ||
+    unitLower === 'kilometre' ||
+    unitLower === 'kilometers' ||
+    unitLower === 'kilometer'
+  ) {
+    unitLower = 'km';
+  } else if (unitLower === 'miles' || unitLower === 'mile') {
+    unitLower = 'm';
+  } else {
+    throw new Error(
+      'Please provide the unit identifier as either "km" for kilometres or "m" for miles'
+    );
+  }
+
+  return unitLower;
+}
+
+/**
+ *
+ * @param   {number}    radiusDistance  The user given distance in either miles or km.
+ * @param   {string}    distanceUnit    The user chosen distance unit (miles or km).
+ * @param   {function}  projection      The D3 projection function.
+ * @param   {Array}     center          The center coordinates of the drawing area.
+ * @return  {Object}                    The geo circle, the radius in degrees and in pixel.
+ */
+export default function(radiusDistance, distanceUnit, projection, center) {
+  // Get radius in degrees
+  const unit = getUnitString(distanceUnit);
+  const RADIUS_EARTH = unit === 'm' ? 3959 : 6371;
+  const radiusRadians = radiusDistance / RADIUS_EARTH;
+  const radiusDegrees = radiusRadians * (180 / Math.PI);
+
+  // Get geo circle data.
+  const circlePolygon = geoCircle()
+    .radius(radiusDegrees)
+    .center(projection.invert(center));
+
+  // Get radius in pixel.
+  const radiusPixel = getPixelRadius(circlePolygon(), projection);
+
+  return { circlePolygon, radiusDegrees, radiusPixel };
+}

--- a/src/getImageCenters.js
+++ b/src/getImageCenters.js
@@ -8,7 +8,7 @@
  * @param  {Array}              size        Width and height of drawing canvas.
  * @param  {number}             precision   Hidden canvas ratio of the
  *                                          drawing canvas.
- * @return {Array}                          Hexagon centers covering 
+ * @return {Array}                          Hexagon centers covering
  *                                          the displayed object.
  */
 // export default function(centers, image, size, precision) {
@@ -18,14 +18,15 @@ export default function(centers, image, size) {
   return centers
     .filter(center => {
       return (
-        // Vouch for centers to be within bounds.
-        center[0] >= 0 && center[0] <= w &&
-        center[1] >= 0 && center[1] <= h &&
-        image[Math.floor(center[0]) +  
-              Math.floor(center[1]) * w]
+        // Guarantee centers to be within bounds.
+        center[0] >= 0 &&
+        center[0] <= w &&
+        center[1] >= 0 &&
+        center[1] <= h &&
+        image[Math.floor(center[0]) + Math.floor(center[1]) * Math.floor(w)]
       );
     })
-    .map((center,i) => { 
-      return { id: i, x: center[0], y: center[1], gridpoint: 1, cover: 1 }
+    .map((center, i) => {
+      return { id: i, x: center[0], y: center[1], gridpoint: 1, cover: 1 };
     });
 }

--- a/src/setHexGenerator.js
+++ b/src/setHexGenerator.js
@@ -2,29 +2,14 @@ import { hexbin } from 'd3-hexbin';
 
 /**
  * Configure the hexbin generator.
- * @param  {Array}    userExtent    Set as either an extent or a size.
- * @param  {number}   radius        The desired hex radius.
- * @return {function}               Hexbin generator function.
+ * @param  {Array}    extent   Drawing area extent.
+ * @param  {number}   radius   The desired hex radius.
+ * @return {function}          Hexbin generator function.
  */
-export default function(userExtent, radius) {
-  // Set the hexbin's extent.
-  const nestedArrayLength = Array.from(
-    new Set(userExtent.map(e => e.length))
-  )[0];
-  let extent = Array(2);
-
-  if (nestedArrayLength === 2) {
-    extent = userExtent;
-  } else if (nestedArrayLength === undefined) {
-    extent = [[0, 0], userExtent];
-  } else {
-    throw new Error(
-      "Check 'extent' is in the anticipated form [[x0,y0],[x1,y1]] or [x1,y1]"
-    );
-  }
-
+export default function(extent, radius) {
   // Set the hexbin generator. Note, x and y will
   // be set later when prepping the user data.
+  // Also round radius to the nearest 0.5 step.
   return hexbin()
     .extent(extent)
     .radius(radius)

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,29 @@
+import { extent } from 'd3-array';
+
+/**
+ * Checks and if required converts the 1D extent to a 2D extent.
+ * @param {Array} userExtent  Either the full 2D extent or just width and height.
+ * @return                    The full 2D extent.
+ */
+export function expandExtent(userExtent) {
+  const nestedArrayLength = Array.from(
+    new Set(userExtent.map(e => e.length))
+  )[0];
+  let extentLong = Array(2);
+
+  if (nestedArrayLength === 2) {
+    extentLong = userExtent;
+  } else if (nestedArrayLength === undefined) {
+    extentLong = [[0, 0], userExtent];
+  } else {
+    throw new Error(
+      "Check 'extent' is in the anticipated form [[x0,y0],[x1,y1]] or [x1,y1]"
+    );
+  }
+
+  return extentLong;
+}
+
 /**
  * Checks and sets given value to greater than 0.
  * @param  {number} v       Value.
@@ -51,4 +77,20 @@ export function hexDraw(context, corners, colour, action = 'fill') {
   } else {
     throw new Error("hexDraw action needs to be either 'fill' or 'stroke'");
   }
+}
+
+/**
+ * Calculates the circle radius in pixel, given a circle polygon.
+ * @param   {Object}    geoCirclePolygon  The circle polygon.
+ * @param   {function}  projection        The D3 projection function.
+ * @return  {number}                      The radius in pixel.
+ */
+export function getPixelRadius(geoCirclePolygon, projection) {
+  // Get radius in pixel.
+  const circleDataGeo = geoCirclePolygon.coordinates[0];
+  const circleDataY = circleDataGeo.map(d => projection(d)[1]);
+  const circleDiameter = extent(circleDataY);
+  const radiusPixel = (circleDiameter[1] - circleDiameter[0]) / 2;
+
+  return radiusPixel;
 }

--- a/test/hexgrid.test.js
+++ b/test/hexgrid.test.js
@@ -1,26 +1,25 @@
 // Libraries.
 const tape = require('tape'),
-      d3Geo = require('d3-geo'),
-      topojson = require('topojson'),
-      JSDOM = require('jsdom').JSDOM,
-      hexgrid = require('../').hexgrid;
+  d3Geo = require('d3-geo'),
+  JSDOM = require('jsdom').JSDOM,
+  hexgrid = require('../').hexgrid;
 
 // Data.
 const luxGeo = require('./data/lux_adm0.json'),
-      luxCities = require('./data/lux_cities.json');
+  luxCities = require('./data/lux_cities.json');
 
 // Helper functions.
 
 /**
- * Check if array all object properties are congrunent.
+ * Check if all object properties are congruent.
  * @param  {Array} keyList  Array of properties for each object.
  * @return {boolean}        true for congruent properties • false for deviance.
  */
 function getKeyEquality(keyList) {
-  const keyEquality = []
-  for(let i = 0; i < keyList.length; i++) {
-    if (i==0) continue;    
-    var equality = keyList[i-1].join() === keyList[i].join();
+  const keyEquality = [];
+  for (let i = 0; i < keyList.length; i++) {
+    if (i == 0) continue;
+    var equality = keyList[i - 1].join() === keyList[i].join();
     keyEquality.push(equality);
   }
   return Array.from(new Set(keyEquality))[0];
@@ -29,12 +28,12 @@ function getKeyEquality(keyList) {
 /**
  * Get unique object properties across array.
  * @param  {Array} keys   Array of objects with keys to test.
- * @return {Array}        Array of unique keys.      
+ * @return {Array}        Array of unique keys.
  */
 function getUniqueKeys(layout) {
-  const allKeys = layout.reduce((res, el) => { 
+  const allKeys = layout.reduce((res, el) => {
     return res.concat(Object.keys(el));
-  },[]);
+  }, []);
 
   return Array.from(new Set(allKeys));
 }
@@ -44,7 +43,9 @@ const dom = new JSDOM('<!DOCTYPE html><title>fake dom</title>');
 global.document = dom.window.document;
 
 // Set up the hexgrid
-const w = 100, h = 100, geo = luxGeo;
+const w = 100,
+  h = 100,
+  geo = luxGeo;
 
 const projection = d3Geo.geoMercator().fitSize([w, h], luxGeo);
 const geoPath = d3Geo.geoPath().projection(projection);
@@ -55,43 +56,57 @@ const t = hexgrid()
   .projection(projection)
   .pathGenerator(geoPath)
   .hexRadius(4);
-  
+
 const hex = t([]);
 const hexData = t(luxCities);
 const hexDataWithKeys = t(luxCities, ['Name', 'Population']);
 
-
 tape('The hexgrid function returns an object', test => {
   let actual, expected;
 
-  actual = hex.grid.constructor.name, 
-  expected = 'Object';
+  (actual = hex.grid.constructor.name), (expected = 'Object');
   test.equal(actual, expected, 'called "grid".');
 
-  actual = hex.grid.layout.constructor.name, 
-  expected = 'Array';
-  test.equal(actual, expected, 'with a property called "layout" of type "Array".');
+  (actual = hex.grid.layout.constructor.name), (expected = 'Array');
+  test.equal(
+    actual,
+    expected,
+    'with a property called "layout" of type "Array".'
+  );
 
-  actual = hex.grid.imageCenters.constructor.name, 
-  expected = 'Array';
-  test.equal(actual, expected, 'with a property called "imageCenters" of type "Array".');
+  (actual = hex.grid.imageCenters.constructor.name), (expected = 'Array');
+  test.equal(
+    actual,
+    expected,
+    'with a property called "imageCenters" of type "Array".'
+  );
 
-  actual = hex.grid.extentPoints.constructor.name,
-  expected = 'Array';
-  test.equal(actual, expected, 'with a property called "extentPoints" of type "Array".');
+  (actual = hex.grid.extentPoints.constructor.name), (expected = 'Array');
+  test.equal(
+    actual,
+    expected,
+    'with a property called "extentPoints" of type "Array".'
+  );
 
-  actual = hex.grid.extentPointsWeighted.constructor.name,
-  expected = 'Array';
-  test.equal(actual, expected, 'with a property called "extentPointsWeighted" of type "Array".');
+  (actual = hex.grid.extentPointsWeighted.constructor.name),
+    (expected = 'Array');
+  test.equal(
+    actual,
+    expected,
+    'with a property called "extentPointsWeighted" of type "Array".'
+  );
 
-  actual = hex.grid.extentPointDensity.constructor.name,
-  expected = 'Array';
-  test.equal(actual, expected, 'with a property called "extentPointDensity" of type "Array".');
+  (actual = hex.grid.extentPointDensity.constructor.name), (expected = 'Array');
+  test.equal(
+    actual,
+    expected,
+    'with a property called "extentPointDensity" of type "Array".'
+  );
 
   test.end();
 });
 
-tape('The hexgrid\'s layout array holds objects', test => {
+tape("The hexgrid's layout array holds objects", test => {
   let actual, expected;
 
   // Check all objects share the same keys.
@@ -107,7 +122,11 @@ tape('The hexgrid\'s layout array holds objects', test => {
 
   actual = uniqueKeys.length;
   expected = 7;
-  test.equal(actual, expected, 'with seven keys if no user data is passed through.');
+  test.equal(
+    actual,
+    expected,
+    'with seven keys if no user data is passed through.'
+  );
 
   expected = true;
   actual = uniqueKeys.includes('x');
@@ -133,104 +152,215 @@ tape('The hexgrid function run with a geography returns an object', test => {
 
   actual = hex.grid.layout.length > 90;
   expected = true;
-  test.equal(actual, expected, 'with a "layout" array of length greater than the expected number.');
+  test.equal(
+    actual,
+    expected,
+    'with a "layout" array of length greater than the expected number.'
+  );
 
   actual = hex.grid.imageCenters.length > 90;
   expected = true;
-  test.equal(actual, expected, 'with an "imageCenters" array of length greater than the expected number.');
+  test.equal(
+    actual,
+    expected,
+    'with an "imageCenters" array of length greater than the expected number.'
+  );
 
   test.end();
 });
 
-tape('The hexgrid function run with a geography and user data returns an object', test => {
+tape(
+  'The hexgrid function run with a geography and user data returns an object',
+  test => {
+    let actual, expected;
+
+    actual = hexData.grid.extentPoints[0];
+    expected = 1;
+    test.equal(
+      actual,
+      expected,
+      'with the expected minimum of datapoints per hexagon.'
+    );
+
+    actual = hexData.grid.extentPoints[1];
+    expected = 1;
+    test.equal(
+      actual,
+      expected,
+      'with the expected maximum of datapoints per hexagon.'
+    );
+
+    // Check length of hexagons with datapoints.
+    const layout = hexData.grid.layout;
+    const points = layout.filter(d => d.datapoints).map(d => d.length > 0);
+    let length = Array.from(new Set(points))[0];
+
+    actual = length;
+    expected = true;
+    test.equal(
+      actual,
+      expected,
+      'with a "layout" property holding hexagons with a length greater than 0 if they contain datapoints.'
+    );
+
+    // Check lengthh of hexagons without datapoints.
+    const noPoints = layout.filter(d => !d.datapoints).map(d => d.length > 0);
+    length = Array.from(new Set(noPoints))[0];
+
+    actual = length;
+    expected = false;
+    test.equal(
+      actual,
+      expected,
+      'with a "layout" property holding hexagons with a length of 0 if they do not contain datapoints.'
+    );
+
+    // Check cover of external hexagons.
+    const edges = layout
+      .filter(d => d.cover < 1 && d.datapoints)
+      .map(d => d.datapointsWt > d.datapoints);
+
+    actual = Array.from(new Set(edges))[0];
+    expected = true;
+    test.equal(
+      actual,
+      expected,
+      'with a "layout" property holding edge hexagons with up-weighted datapoints.'
+    );
+
+    // Check cover of internal hexagons.
+    const internal = layout
+      .filter(d => d.cover === 1 && d.datapoints)
+      .map(d => d.datapointsWt === 1);
+
+    actual = Array.from(new Set(edges))[0];
+    expected = true;
+    test.equal(
+      actual,
+      expected,
+      'with a "layout" property holding internal hexagons with no up-weighted datapoints.'
+    );
+
+    test.end();
+  }
+);
+
+tape(
+  'Given a geography, user data and user variables, only the layout objects WITH datapoints',
+  test => {
+    let actual, expected;
+
+    // Check user variables have been passed through.
+    const filter = hexDataWithKeys.grid.layout.filter(d => d.datapoints);
+    const keyArray = filter.map(d => Object.keys(d));
+
+    actual = getKeyEquality(keyArray);
+    expected = true;
+    test.equal(actual, expected, 'share the same properties.');
+
+    // Check unique key names.
+    const uniqueKeys = getUniqueKeys(filter);
+
+    actual = uniqueKeys.length;
+    expected = 8;
+    test.equal(
+      actual,
+      expected,
+      'have eight keys (all keys + Array index 0) if the maximum number of datapoints per hex is 1.'
+    );
+
+    // Check equality of key names.
+    const datapointKeyArray = filter.map(d => Object.keys(d[0]));
+
+    actual = getKeyEquality(datapointKeyArray);
+    expected = true;
+    test.equal(
+      actual,
+      expected,
+      'hold datapoint objects with the same properties.'
+    );
+
+    // Check unique key names.
+    const datapoints = filter.map(d => d[0]);
+    const datapointsUniqueKeys = getUniqueKeys(datapoints);
+
+    actual = datapointsUniqueKeys.length;
+    expected = 4;
+    test.equal(
+      actual,
+      expected,
+      'hold datapoint objects with the expected number of properties.'
+    );
+
+    expected = true;
+    actual = datapointsUniqueKeys.includes('x');
+    test.equal(
+      actual,
+      expected,
+      'hold datapoint objects with an "x" property.'
+    );
+    actual = datapointsUniqueKeys.includes('y');
+    test.equal(actual, expected, 'hold datapoint objects with a "y" property.');
+    actual =
+      datapointsUniqueKeys.includes('Name') &&
+      datapointsUniqueKeys.includes('Population');
+    test.equal(
+      actual,
+      expected,
+      'hold datapoint objects with the passed in user variables.'
+    );
+
+    test.end();
+  }
+);
+
+const tM = hexgrid()
+  .extent([w, h])
+  .geography(geo)
+  .projection(projection)
+  .pathGenerator(geoPath)
+  .hexRadius(50, 'm');
+
+const tKm = hexgrid()
+  .extent([w, h])
+  .geography(geo)
+  .projection(projection)
+  .pathGenerator(geoPath)
+  .hexRadius(50, 'km');
+
+const radiusM = tM([]).radius();
+const radiusKm = tKm([]).radius();
+
+tape('Given a user defined distance unit', test => {
   let actual, expected;
 
-  actual = hexData.grid.extentPoints[0];
-  expected = 1;
-  test.equal(actual, expected, 'with the expected minimum of datapoints per hexagon.')
+  // const radiusM = hexUnitM.radius();
+  // const radiusKm = hexUnitKm.radius();
 
-  actual = hexData.grid.extentPoints[1];
-  expected = 1;
-  test.equal(actual, expected, 'with the expected maximum of datapoints per hexagon.')
+  actual = typeof radiusM;
+  expected = 'number';
 
-  // Check length of hexagons with datapoints.
-  const layout = hexData.grid.layout;
-  const points = layout.filter(d => d.datapoints).map(d => d.length > 0);
-  let length = Array.from(new Set(points))[0];
+  test.equal(actual, expected, 'the converted radius should be a number.');
 
-  actual = length;
+  actual = radiusM;
+  expected = 102;
+
+  test.equal(
+    actual,
+    expected,
+    'the converted radius should be the expected number.'
+  );
+
+  actual = radiusM > radiusKm;
   expected = true;
-  test.equal(actual, expected, 'with a "layout" property holding hexagons with a length greater than 0 if they contain datapoints.')
 
-  // Check lengthh of hexagons without datapoints.
-  const noPoints = layout.filter(d => !d.datapoints).map(d => d.length > 0);
-  length = Array.from(new Set(noPoints))[0];
-
-  actual = length;
-  expected = false;
-  test.equal(actual, expected, 'with a "layout" property holding hexagons with a length of 0 if they do not contain datapoints.')
-
-  // Check cover of external hexagons.
-  const edges = layout
-    .filter(d => d.cover < 1 && d.datapoints)
-    .map(d => d.datapointsWt > d.datapoints);
-
-  actual = Array.from(new Set(edges))[0];
-  expected = true;
-  test.equal(actual, expected, 'with a "layout" property holding edge hexagons with up-weighted datapoints.')
-
-  // Check cover of internal hexagons.
-  const internal = layout
-    .filter(d => d.cover === 1 && d.datapoints)
-    .map(d => d.datapointsWt === 1);
-
-  actual = Array.from(new Set(edges))[0];
-  expected = true;
-  test.equal(actual, expected, 'with a "layout" property holding internal hexagons with no up-weighted datapoints.')
-
-  test.end()
-});
-
-tape('If supplied with a geography, user data and user variables, only the layout objects WITH datapoints', test => {
-  let actual, expected;
-
-  // Check user variables have been passed through.
-  const filter = hexDataWithKeys.grid.layout.filter(d => d.datapoints);
-  const keyArray = filter.map(d => Object.keys(d));
-
-  actual = getKeyEquality(keyArray);
-  expected = true;
-  test.equal(actual, expected, 'share the same properties.');
-
-  // Check unique key names.
-  const uniqueKeys = getUniqueKeys(filter);
-
-  actual = uniqueKeys.length;
-  expected = 8;
-  test.equal(actual, expected, 'have eight keys (all keys + Array index 0) if the maximum number of datapoints per hex is 1.');
-
-  // Check equality of key names.
-  const datapointKeyArray = filter.map(d => Object.keys(d[0]));
-
-  actual = getKeyEquality(datapointKeyArray);
-  expected = true;
-  test.equal(actual, expected, 'hold datapoint objects with the same properties.');
-
-  // Check unique key names.
-  const datapoints = filter.map(d => d[0]);
-  const datapointsUniqueKeys = getUniqueKeys(datapoints);
-
-  actual = datapointsUniqueKeys.length;
-  expected = 4;
-  test.equal(actual, expected, 'hold datapoint objects with the expected number of properties.');
-
-  expected = true;
-  actual = datapointsUniqueKeys.includes('x');
-  test.equal(actual, expected, 'hold datapoint objects with an "x" property.');
-  actual = datapointsUniqueKeys.includes('y');
-  test.equal(actual, expected, 'hold datapoint objects with§ a "y" property.');
-  actual = datapointsUniqueKeys.includes('Name') && datapointsUniqueKeys.includes('Population');
-  test.equal(actual, expected, 'hold datapoint objects with the passed in user variables.');
+  test.equal(
+    actual,
+    expected,
+    'the converted miles radius should be larger than the converted km radius.'
+  );
 
   test.end();
+
+  console.log(actual, expected);
 });


### PR DESCRIPTION
- Converts miles/kilometres `hexRadius` to pixel.
Also:
- Stabilises image detection.
- Reduces possible decimals of `hexRadius` value.

Closes #2 
Closes #3
Closes #4